### PR TITLE
Updating style of the header component with tailwindcss

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,6 +1,9 @@
 import React from "react"
 import { ThemeProvider } from "./src/context/ThemeContext"
 import "tailwindcss/dist/base.css"
+import "tailwindcss/dist/components.css"
+import "tailwindcss/dist/utilities.css"
+import "./src/styles/base.css"
 
 const wrapRootElement = ({ element }) => (
   <ThemeProvider>{element}</ThemeProvider>

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "react-dom": "^16.12.0",
     "react-helmet": "^5.2.1",
     "styled-components": "^5.0.1",
-    "tailwindcss": "^1.2.0"
+    "tailwindcss": "^1.2.0",
+    "twin.macro": "^1.0.0-alpha.8"
   },
   "devDependencies": {
     "babel-eslint": "^10.1.0",
@@ -34,8 +35,7 @@
     "eslint-plugin-react": "^7.19.0",
     "gatsby-plugin-eslint": "^2.0.8",
     "husky": "^4.2.3",
-    "prettier": "^1.19.1",
-    "twin.macro": "^1.0.0-alpha.8"
+    "prettier": "^1.19.1"
   },
   "keywords": [
     "gatsby"

--- a/src/components/header.js
+++ b/src/components/header.js
@@ -1,90 +1,13 @@
 import { Link, graphql, StaticQuery } from "gatsby"
 import React from "react"
-import BackgroundImage from "gatsby-background-image"
 import styled from "styled-components"
-// import Menu from "./menu"
+import tw from "twin.macro"
+import { theme as themeTw } from "../../tailwind.config"
 
 import ThemeContext from "../context/ThemeContext"
 import ElSalvadorConectadoLogo from "../images/elsalvadorconectado-logo.svg"
 
 const blueTransparentColor = "rgba(23, 72, 237, 0.85)"
-
-const StyledWrapper = styled.div`
-  .logo {
-    width: 172.72px;
-    margin: auto;
-    display: block;
-  }
-
-  .headline {
-    color: #fff;
-    padding-top: 80px;
-    font-weight: 700;
-    font-size: 36px;
-    text-align: center;
-
-    span {
-      font-weight: 400;
-    }
-  }
-
-  .header_cta__wrapper {
-    text-align: center;
-  }
-
-  .header_cta {
-    color: #fff;
-    font-family: "Montserrat";
-    font-weight: 500;
-    font-size: 24px;
-    padding: 13px 6px;
-    position: relative;
-
-    ::before {
-      content: "";
-      position: absolute;
-      top: 0;
-      left: 0;
-      background-color: #8ca2ec;
-      opacity: 0.85;
-      width: 31px;
-      height: 100%;
-      transition: width 1s ease-out;
-    }
-
-    &:hover {
-      ::before {
-        width: 100%;
-      }
-    }
-  }
-
-  @media (min-width: 376px) {
-    .headline span {
-      display: block;
-    }
-  }
-
-  @media (min-width: 769px) {
-    .logo {
-      display: initial;
-      margin: 0;
-    }
-
-    .headline {
-      font-size: 62px;
-      text-align: left;
-    }
-
-    .header_cta__wrapper {
-      text-align: left;
-    }
-
-    .header_cta {
-      font-size: 32px;
-    }
-  }
-`
 
 const Header = () => (
   <StaticQuery
@@ -105,74 +28,47 @@ const Header = () => (
       // Set ImageData
       const imageFluid = data.desktop.childImageSharp.fluid
       return (
-        <StyledWrapper>
-          <BackgroundImage
-            Tag="section"
-            className="test-bg"
-            fluid={imageFluid}
-            backgroundColor={blueTransparentColor}
-          >
+        <StyledWrapper className="header" imageFluid={imageFluid} bgColor={blueTransparentColor}>
+          <div className="header__hero">
             <ThemeContext.Consumer>
               {(theme) => (
-                <div
-                  style={{
-                    minHeight: "840px"
-                  }}
-                >
+                <div className="header__hero__container container">
                   <button type="button" className="dark-switcher" onClick={theme.toggleDark}>
                     {theme.dark ? <span>☀</span> : <span>☾</span>}
                   </button>
-                  <div
-                    style={{
-                      margin: "0 auto",
-                      maxWidth: 960,
-                      padding: "0 1.0875rem"
-                    }}
-                  >
-                    <div style={{ paddingTop: "140px" }}>{/* spacing */}</div>
-                    <Link className="logo" to="/">
+                  <div className="header__hero__container__text">
+                    <Link className="header__hero__container__text__logo" to="/">
                       <img
                         src={ElSalvadorConectadoLogo}
                         alt="El texto se lee El Salvador Conectado con un logotipo formando una especie de abrazo"
-                        style={{
-                          height: "75px",
-                          width: "254px"
-                        }}
                       />
                     </Link>
 
                     {/* <Menu /> */}
 
-                    <h1 className="headline">
-                      <span>{"El Salvador es más "}</span>
+                    <h1 className="header__hero__container__text__message">
+                      <span className="header__hero__container__text__message__light">
+                        {"El Salvador es más "}
+                      </span>
                       si está conectado
                     </h1>
 
-                    <div style={{ height: "48px" }}>{/* spacing */}</div>
-
-                    <div className="header_cta__wrapper">
-                      <Link
-                        className="header_cta"
+                    <div className="header__hero__container__text__button">
+                      <a
+                        className="header__hero__container__text__button__href"
                         href="http://unete.elsalvadorconectado.org"
                         target="_blank"
                         rel="noopener noreferrer"
                       >
                         Únete ahora →
-                      </Link>
+                      </a>
                     </div>
                   </div>
                 </div>
               )}
             </ThemeContext.Consumer>
-          </BackgroundImage>
-          <div
-            className="test-this"
-            style={{
-              margin: "0 auto",
-              maxWidth: 960,
-              padding: "0 1.0875rem"
-            }}
-          >
+          </div>
+          <div>
             <span>
               Photo by
               {" "}
@@ -200,5 +96,117 @@ const Header = () => (
     }}
   />
 )
+
+const StyledWrapper = styled.div`
+  .header__hero {
+    background-image: url(${(props) => props.imageFluid.src});
+    ${tw`bg-local bg-center bg-no-repeat bg-cover`}
+    ${tw`relative`}
+
+    &::after {
+      ${tw`absolute inset-0 w-full h-full`}
+      content: " ";
+      z-index: 0;
+      background-color: ${(props) => props.bgColor};
+    }
+
+    &__container {
+      ${tw`font-montserrat text-white`}
+      ${tw`relative`}
+      ${tw`mx-auto`}
+      z-index: 1;
+
+      &__text {
+        ${tw`h-screen flex flex-col justify-around items-center`}
+        ${tw`text-4xl`}
+
+        &__logo {
+          ${tw`w-2/4`}
+          ${tw`flex justify-center`}
+
+          img {
+            ${tw`mb-0`}
+          }
+        }
+
+        &__message {
+          ${tw`text-center font-bold`}
+          ${tw`flex flex-col justify-center items-center`}
+
+          &__light {
+            ${tw`font-normal`}
+          }
+        }
+
+        &__button {
+          ${tw`text-2xl font-bold underline`}
+
+          &__href {
+            ${tw`flex justify-center items-center`}
+            ${tw`relative`}
+
+            &::after {
+              content: '';
+              ${tw`absolute inset-0 h-full w-1/12`}
+              background-color: #8ca2ec;
+              opacity: 0.50;
+              transition: width 1s ease-out;
+            }
+
+            &:hover {
+              &::after {
+                ${tw`w-full`}
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+@media (min-width: ${themeTw.extend.screens.tablet}) {
+  .hero__container__text__button__href {
+    ${tw`text-3xl`}
+  }
+
+  .header__hero__container__text__message {
+    ${tw`text-5xl`}
+  }
+}
+
+@media (min-width: ${themeTw.extend.screens.laptop}) {
+  .header__hero {
+    &__container__text {
+      ${tw`items-start justify-start`}
+      ${tw`py-24`}
+
+      &__logo {
+        ${tw`justify-start`}
+        ${tw`w-1/4`}
+      }
+
+      &__message {
+        ${tw`pt-20`}
+      }
+
+      &__button {
+        ${tw`pt-8`}
+      }
+    }
+  }
+}
+
+@media (min-width: ${themeTw.extend.screens.desktop}) {
+  .header__hero__container__text__message {
+    ${tw`pt-24`}
+    ${tw`text-6xl`}
+  }
+
+  .header__hero__container__text__button {
+    ${tw`pt-12`}
+    ${tw`text-4xl`}
+  }
+}
+`
 
 export default Header

--- a/src/components/layout.css
+++ b/src/components/layout.css
@@ -1,5 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;700&display=swap');
-
+@import url('https://fonts.googleapis.com/css?family=Poppins:300,300i,400,400i,500,500i,600,600i|Montserrat:300,300i,400,400i,500,500i,600,600i,700,700i,800,800i&display=swap');
 html {
   font-family: sans-serif;
   -ms-text-size-adjust: 100%;

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -1,0 +1,13 @@
+@media (min-width: 1024px) {
+  .container {
+    padding-right: 5rem;
+    padding-left: 5rem;
+  }
+}
+
+@media (min-width: 1280px) {
+  .container {
+    padding-right: 4rem;
+    padding-left: 4rem;
+  }
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,6 +1,18 @@
 module.exports = {
   theme: {
-    extend: {}
+    extend: {
+      fontFamily: {
+        montserrat: "Montserrat, sans-serif",
+        poppins: "Poppins, sans-serif"
+      },
+      // https://tailwindcss.com/docs/breakpoints
+      // https://tailwindcss.com/docs/container
+      screens: {
+        tablet: "768px",
+        laptop: "1024px",
+        desktop: "1280px"
+      }
+    }
   },
   variants: {},
   plugins: []


### PR DESCRIPTION
# Antes de enviar el Pull Request
- [x] Confirmo que revisé que mis cambios funcionan
- [x] He adjuntado una imagen de cómo se ven mis cambios (si aplica)
- [x] He ejecutado prettier en los archivos de mis cambios

# Dependencias
- Estas actualizaciones dependen del PR #7 
- Éste PR resuelve el issue #9 

# Intro
- Haciendo actualización de estilo al componente _header_ pero utilizando TailwindCSS
- Se hizo reestructura del componente y solamente dejando cada elemento HTML con la respectiva clase, para posteriormente usar `styled-components` para poder aplicarles las clases que TailwindCSS nos proporciona, pero todo posible gracias al paquete `twin.macro` que es el que devuelve en forma de objeto las clases de tailwind y las agrega al elemento seleccionado
- Agregando los demás archivos base de TailwindCSS en la configuración del proyecto
- Agregando configuración personalizada en el archivo que configura al paquete tailwind, en el cual se agregaron las fuentes que utilizará el sitio
- Agregando un archivo base de css que en el cual se extiende la clase `container` de tailwind para que tenga padding en el eje X dependiendo del tipo de dispositivo en el cual el sitio sea visitado
- Nota: `twin.macro` no soporta la clase `container` de tailwind, por tal motivo la clase `container` tiene que agregarse directamente en el elemento en el cual queremos utilizar la clase
- Nota: Debido a que se usa `styled-components`, no encontré forma de hacer funcionar directamente los `break-points` de tailwind, por tal motivo se importan las variables de tailwind que contienen los pixeles de cada `break-points`, el archivo que las contienes es el archivo `tailwind.config.js` en la raíz del proyecto


# Pruebas

- Móvil

![Móvil](https://user-images.githubusercontent.com/13499566/78737415-ac916680-790c-11ea-996c-58089bcf0a5f.png)


- Tablet

![Tablet](https://user-images.githubusercontent.com/13499566/78737424-b0bd8400-790c-11ea-9653-171bedcc154f.png)

- Laptop

![Laptop](https://user-images.githubusercontent.com/13499566/78737438-b5823800-790c-11ea-8c98-ce01530873e7.png)
